### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,6 @@ Check it is up
 docker logs -f local_db
 ```
 
-Create an empty development database:
-
-```
-docker exec -it local_db psql -U local_dev -c "create database local_db" -d template1
-```
 
 Check that you can log into a database with `psql`
 


### PR DESCRIPTION
Development local_db is created during the initial `docker-compose  up` run, no need to create it manually (it would throw an error as the DB already exists).